### PR TITLE
scanner needs to tokenize interpolations properly

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -375,6 +375,7 @@ func (s *Scanner) scanExponent(ch rune) rune {
 
 // scanString scans a quoted string
 func (s *Scanner) scanString() {
+	braces := 0
 	for {
 		// '"' opening already consumed
 		// read character after quote
@@ -387,6 +388,19 @@ func (s *Scanner) scanString() {
 
 		if ch == '"' {
 			break
+		}
+		
+		// If we're going into a ${} then we can ignore quotes for awhile.
+		// This is a weird HCL-ism but most places HCL is use also use this
+		// syntax for interpolations.
+		if braces == 0 && ch == '$' && s.peek() == '{' {
+			braces++
+			s.next()
+		} else if braces > 0 && ch == '{' {
+			braces++
+		}
+		if braces > 0 && ch == '}' {
+			braces--
 		}
 
 		if ch == '\\' {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -386,7 +386,7 @@ func (s *Scanner) scanString() {
 			return
 		}
 
-		if ch == '"' {
+		if ch == '"' && braces == 0 {
 			break
 		}
 		

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -74,6 +74,7 @@ var tokenLists = map[string][]tokenPair{
 		{token.STRING, `" "`},
 		{token.STRING, `"a"`},
 		{token.STRING, `"本"`},
+		{token.STRING, `"${file("foo")}"`},
 		{token.STRING, `"\a"`},
 		{token.STRING, `"\b"`},
 		{token.STRING, `"\f"`},


### PR DESCRIPTION
This is a weird HCL-ism bug that I found while attempting to port your parser. I've done this already in my branch on hashicorp/hcl but figured I should upstream this in the mean time.

The backstory: we treat `${}` as a weird black hole for ending the string until we see `}`, so we allow double quotes within double quotes. It is certainly weird, but a decision we can't back out on today!
